### PR TITLE
Refactor zap caller encoder to enable clickable paths in GoLand console

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -62,16 +62,16 @@ func WithContext(ctx context.Context, logger *zap.Logger) *zap.Logger {
 	return logger
 }
 
-//// prettyEncodeCaller add padding to the caller string
-//func prettyEncodeCaller(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
-//	const fixedWidth = 25
-//	callerStr := caller.TrimmedPath()
-//	if len(callerStr) < fixedWidth {
-//		callerStr += strings.Repeat(" ", fixedWidth-len(callerStr))
-//	}
-//	callerStr += "\t"
-//	enc.AppendString(callerStr)
-//}
+// prettyEncodeCaller add padding to the caller string
+func prettyEncodeCaller(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
+	const fixedWidth = 25
+	callerStr := caller.TrimmedPath()
+	if len(callerStr) < fixedWidth {
+		callerStr += strings.Repeat(" ", fixedWidth-len(callerStr))
+	}
+	callerStr += "\t"
+	enc.AppendString(callerStr)
+}
 
 func relativePrettyCallerEncoder(rootDir string) zapcore.CallerEncoder {
 	const fixedWidth = 40

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -73,6 +73,8 @@ func prettyEncodeCaller(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEn
 	enc.AppendString(callerStr)
 }
 
+// relativePrettyCallerEncoder returns a zapcore.CallerEncoder that formats the caller path relative to the root directory
+// it enables clickable links in the GoLand console output
 func relativePrettyCallerEncoder(rootDir string) zapcore.CallerEncoder {
 	const fixedWidth = 40
 


### PR DESCRIPTION
## Type of changes
- Refactor

## Purpose
- Improve log readability by displaying relative file paths for internal sources and condensed paths for external libraries.


## Additional Information

- Introduced `relativePrettyCallerEncoder` to replace `EncodeCaller` with a custom formatter.
- When a log originates from within the project root, it displays a relative path (e.g., `internal/foo/bar.go:12`).
- For logs from external libraries, the path is prefixed with `external/` and only the last few components are kept (e.g., `external/go/pkg/mod/foo.go:34`).
- This helps distinguish between internal and external log sources, making logs cleaner and more informative during development.
- Added fixed width padding to align output visually.

![image](https://github.com/user-attachments/assets/6264c2c3-f1ca-4308-ab1f-f313dc04aaba)