### PR TITLE
Skip setting empty slices or arrays in field overrides

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,9 @@ func Merge[T any](base *T, override *T) (*T, error) {
 		zero := reflect.Zero(field.Type()).Interface()
 
 		if field.CanSet() && !reflect.DeepEqual(overrideField.Interface(), zero) {
+			if (overrideField.Kind() == reflect.Slice || overrideField.Kind() == reflect.Array) && overrideField.Len() == 0 {
+				continue
+			}
 			field.Set(overrideField)
 		}
 	}


### PR DESCRIPTION
## Type of change
- Fix

## Purpose
- Don't override array or slice with empty value