### PR TITLE
[CORE-71] Resolve Error Log Caller Location Issue

### DIFF
--- a/pkg/problem/problem.go
+++ b/pkg/problem/problem.go
@@ -87,6 +87,8 @@ func (h *HttpWriter) WriteError(ctx context.Context, w http.ResponseWriter, err 
 		}
 	}
 
+	logger = logger.WithOptions(zap.AddCallerSkip(1));
+
 	logger.Warn("Handling "+problem.Title, zap.String("problem", problem.Title), zap.Error(err), zap.Int("status", problem.Status), zap.String("type", problem.Type), zap.String("detail", problem.Detail))
 
 	w.Header().Set("Content-Type", "application/problem+json")


### PR DESCRIPTION
# Type of change
- Fix

# Purpose
- Ensure error logs handled by `problem.WriteError` accurately record the caller location.
- By skipping the current caller `problem.WriteError`, which is the error handler function, with the option `zap.AddCallerSkip(1)`, the actual caller that caused the error can correctly shown in the log for error handling.

# Additional information
- [Solution Reference](https://github.com/uber-go/zap/issues/715)
- Official Document: [AddCallerSkip](https://pkg.go.dev/go.uber.org/zap#AddCallerSkip), [WithOptions](https://pkg.go.dev/go.uber.org/zap#SugaredLogger.WithOptions)