### PR TITLE
[CORE-91] Fix mapping of ErrNotFound to 404 response

### DIFF
--- a/pkg/problem/problem.go
+++ b/pkg/problem/problem.go
@@ -76,6 +76,8 @@ func (h *HttpWriter) WriteError(ctx context.Context, w http.ResponseWriter, err 
 			problem = NewUnauthorizedProblem("You must be logged in to access this resource")
 		case errors.Is(err, handlerutil.ErrInvalidUUID):
 			problem = NewValidateProblem("Invalid UUID format")
+		case errors.Is(err, handlerutil.ErrNotFound):
+			problem = NewNotFoundProblem("Resource not found")
 		case errors.As(err, &internalDbError):
 			problem = NewInternalServerProblem("Internal server error")
 		case errors.Is(err, pagination.ErrInvalidPageOrSize):
@@ -87,7 +89,7 @@ func (h *HttpWriter) WriteError(ctx context.Context, w http.ResponseWriter, err 
 		}
 	}
 
-	logger = logger.WithOptions(zap.AddCallerSkip(1));
+	logger = logger.WithOptions(zap.AddCallerSkip(1))
 
 	logger.Warn("Handling "+problem.Title, zap.String("problem", problem.Title), zap.Error(err), zap.Int("status", problem.Status), zap.String("type", problem.Type), zap.String("detail", problem.Detail))
 


### PR DESCRIPTION
# Type of changes
* Fix

# Purpose
* Correctly translated database error `ErrNotFound` into a 404 response instead of a 500
* Add a new error case to match the error type in core-system-backend.