### PR TITLE
fix: catch JSON UnMarshalType error

### DIFF
--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -19,7 +19,7 @@ func ParseAndValidateRequestBody(ctx context.Context, v *validator.Validate, r *
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		span.RecordError(err)
-		return NewValidationErrorWithErrors("invalid JSON payload", []string{err.Error()})
+		return err
 	}
 	defer func() {
 		err := r.Body.Close()


### PR DESCRIPTION
fix: function `ParseAndValidateRequestBody` return 500 if JSON type doesn't match.
---
more information:
error discovered from clustron-backend fuzzing error. testcase:

PUT /api/settings
curl -X PUT -H 'Authorization: [Filtered]' -H 'Content-Type: application/json' -d '{"fullName": "", "linuxUsername": {}}' http://localhost:8080/api/settings

where linuxUsername should be a string, not an object.