### PR TITLE
Upgrade Go version to v1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NYCU-SDC/summer
 
-go 1.24.2
+go 1.26.2
 
 require (
 	github.com/go-playground/validator/v10 v10.26.0


### PR DESCRIPTION
## Type of changes
- Chore

## Purpose
- Since Go 1.24 has reached its end-of-life, we have upgraded to version 1.26.2.