### PR TITLE
Replace interface{} With Any for Improved Type Clarity

### DIFF
--- a/pkg/database/migration.go
+++ b/pkg/database/migration.go
@@ -16,7 +16,7 @@ type MigrateLogger struct {
 	logger *zap.Logger
 }
 
-func (z *MigrateLogger) Printf(format string, v ...interface{}) {
+func (z *MigrateLogger) Printf(format string, v ...any) {
 	message := fmt.Sprintf(format, v...)
 	message = strings.TrimSpace(message)
 	z.logger.Info("Migration event", zap.String("migration", message))

--- a/pkg/handler/errors.go
+++ b/pkg/handler/errors.go
@@ -48,7 +48,7 @@ func NewNotFoundError(table, key, value, message string) NotFoundError {
 
 type ValidationError struct {
 	Field   string
-	Value   interface{}
+	Value   any
 	Message string
 	Errors  []string
 }
@@ -67,7 +67,7 @@ func (e ValidationError) Is(target error) bool {
 	return errors.Is(target, ErrValidation)
 }
 
-func NewValidationError(field string, value interface{}, message string) ValidationError {
+func NewValidationError(field string, value any, message string) ValidationError {
 	return ValidationError{
 		Field:   field,
 		Value:   value,

--- a/pkg/handler/errors_test.go
+++ b/pkg/handler/errors_test.go
@@ -95,7 +95,7 @@ func TestNewValidationError(t *testing.T) {
 	tests := []struct {
 		name    string
 		field   string
-		value   interface{}
+		value   any
 		message string
 		want    ValidationError
 	}{

--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-func ParseAndValidateRequestBody(ctx context.Context, v *validator.Validate, r *http.Request, s interface{}) error {
+func ParseAndValidateRequestBody(ctx context.Context, v *validator.Validate, r *http.Request, s any) error {
 	_, span := otel.Tracer("internal/handler").Start(ctx, "ParseAndValidateRequestBody")
 	defer span.End()
 
@@ -43,7 +43,7 @@ func ParseAndValidateRequestBody(ctx context.Context, v *validator.Validate, r *
 	return nil
 }
 
-func WriteJSONResponse(w http.ResponseWriter, status int, data interface{}) {
+func WriteJSONResponse(w http.ResponseWriter, status int, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	jsonBytes, err := json.Marshal(data)

--- a/pkg/problem/problem_test.go
+++ b/pkg/problem/problem_test.go
@@ -227,7 +227,7 @@ func TestProblem_JSONSerialization(t *testing.T) {
 			}
 
 			// Compare JSON strings
-			var gotMap, wantMap map[string]interface{}
+			var gotMap, wantMap map[string]any
 			if err := json.Unmarshal(got, &gotMap); err != nil {
 				t.Fatalf("Failed to unmarshal got JSON: %v", err)
 			}


### PR DESCRIPTION
## Type of changes
- Chore

## Purpose
- Replace `interface{}` with the idiomatic `any` alias across handler, database, and problem packages for improved type clarity

## Additional Information
- Mechanical refactor applied via `go fix` with no behavior changes
- Affected files: `pkg/database/migration.go`, `pkg/handler/errors.go`, `pkg/handler/errors_test.go`, `pkg/handler/payload.go`, `pkg/problem/problem_test.go`