### PR TITLE
Add Database Transaction Handling Utilities for pgx and sqlc

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,32 @@ err = databaseutil.WrapMSSQLErrorWithKeyValue(err, "users", "id", id.String(), l
 - If `db` is already `pgx.Tx`, the callback runs on that transaction — no begin/commit/rollback here.
 - Otherwise `db` must implement `TxBeginner` (e.g. `*pgxpool.Pool`): begin, callback, commit on success, rollback on error or panic.
 - Return a non-nil error from the callback to abort and roll back. Do not call `Commit` or `Rollback` inside the callback unless you have a deliberate sub-transaction design.
+- Each `Run()` or `RunWithDBTx()` call is one transaction. Put every query that must commit or roll back together inside that single callback — do not split related work across multiple calls.
+
+```go
+// Incorrect — two separate transactions; Debit may commit even if Credit fails
+err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
+    Run(func(qtx *user.Queries) error {
+        return qtx.Debit(ctx, params)
+    })
+if err != nil {
+    return err
+}
+return databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
+    Run(func(qtx *user.Queries) error {
+        return qtx.Credit(ctx, creditParams)
+    })
+
+// Correct — Debit and Credit share one transaction
+err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
+    Run(func(qtx *user.Queries) error {
+        err := qtx.Debit(ctx, params)
+        if err != nil {
+            return databaseutil.WrapDBError(err, logger, "debit account")
+        }
+        return qtx.Credit(ctx, creditParams)
+    })
+```
 
 | API                                      | Use when                                               |
 | ---------------------------------------- | ------------------------------------------------------ |
@@ -465,21 +491,9 @@ Begin/commit failures are wrapped with `WrapDBError`. Unsupported connections re
 
 ##### WithTransactionQueries
 
-Prefer this for sqlc call sites. `Run` binds `queries.WithTx(tx)` for you; `RunWithDBTx` also passes `pgx.Tx` when another API needs the same transaction.
+Prefer this for sqlc call sites. `Run` binds `queries.WithTx(tx)` for you; use it when every database access in the callback goes through `qtx` (see the example above). `RunWithDBTx` also passes `pgx.Tx` when another service must share the same transaction:
 
 ```go
-// All work through transaction-scoped queries
-err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
-    Run(func(qtx *user.Queries) error {
-        err := qtx.Debit(ctx, params)
-        if err != nil {
-            return databaseutil.WrapDBError(err, logger, "debit account")
-        }
-
-        return qtx.Credit(ctx, creditParams)
-    })
-
-// Share pgx.Tx with another service in the same transaction
 err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
     RunWithDBTx(func(tx pgx.Tx, qtx *user.Queries) error {
         err := audit.Log(ctx, tx, event)

--- a/README.md
+++ b/README.md
@@ -4,26 +4,55 @@ A Go toolkit for building RESTful services at NYCU SDC. Provides a CLI scaffolde
 
 ## Table of Contents
 
-- [Features](#features)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
+- [summer](#summer)
+  - [Table of Contents](#table-of-contents)
+  - [Features](#features)
+  - [Installation](#installation)
+    - [CLI tool](#cli-tool)
+    - [Library packages](#library-packages)
+  - [Quick Start](#quick-start)
     - [CLI: Scaffold a new project](#cli-scaffold-a-new-project)
     - [Run the example](#run-the-example)
-- [Packages](#packages)
+  - [Packages](#packages)
     - [pkg/log](#pkglog)
+      - [Logger configs](#logger-configs)
+      - [WithContext](#withcontext)
     - [pkg/handler](#pkghandler)
+      - [Sentinel errors](#sentinel-errors)
+      - [Structured error types](#structured-error-types)
+      - [ParseAndValidateRequestBody](#parseandvalidaterequestbody)
+      - [WriteJSONResponse](#writejsonresponse)
+      - [ParseUUID](#parseuuid)
     - [pkg/problem](#pkgproblem)
+      - [HttpWriter](#httpwriter)
+      - [WriteError / WriteErrorWithRequest](#writeerror--writeerrorwithrequest)
+      - [Error-to-HTTP mapping (automatic)](#error-to-http-mapping-automatic)
+      - [Problem constructors](#problem-constructors)
     - [pkg/middleware](#pkgmiddleware)
+      - [Building a middleware set](#building-a-middleware-set)
+      - [Applying to a handler](#applying-to-a-handler)
     - [pkg/trace](#pkgtrace)
+      - [TraceMiddleware](#tracemiddleware)
+      - [RecoverMiddleware](#recovermiddleware)
+      - [PanicRecoveryError](#panicrecoveryerror)
     - [pkg/cors](#pkgcors)
     - [pkg/database](#pkgdatabase)
+      - [Migrations](#migrations)
+      - [PostgreSQL error wrapping](#postgresql-error-wrapping)
+      - [MSSQL error wrapping](#mssql-error-wrapping)
+      - [Transaction helpers](#transaction-helpers)
+        - [WithTransactionQueries](#withtransactionqueries)
+        - [WithTransaction](#withtransaction)
     - [pkg/pagination](#pkgpagination)
+      - [Factory](#factory)
+      - [GetRequest](#getrequest)
+      - [NewResponse](#newresponse)
     - [pkg/config](#pkgconfig)
-- [Wiring Everything Together](#wiring-everything-together)
-- [Project Layout](#project-layout)
-- [sqlc Integration](#sqlc-integration)
-- [Contributing](#contributing)
-- [License](#license)
+  - [Wiring Everything Together](#wiring-everything-together)
+  - [Project Layout](#project-layout)
+  - [sqlc Integration](#sqlc-integration)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ---
 
@@ -32,7 +61,7 @@ A Go toolkit for building RESTful services at NYCU SDC. Provides a CLI scaffolde
 - **CLI scaffolder** — `summer init` creates a ready-to-run project with a health endpoint
 - **Structured logging** — Zap-based logger wired for JSON output in production and pretty console output in development, with automatic trace/span ID injection
 - **Tracing** — OpenTelemetry tracing middleware with upstream context propagation
-- **Database** — pgx + golang-migrate helpers for PostgreSQL; MSSQL also supported
+- **Database** — pgx + golang-migrate helpers for PostgreSQL; MSSQL also supported; transaction helpers for pgx and sqlc
 - **Validation** — `go-playground/validator` wrappers with consistent RFC 9457 problem-detail error responses
 - **Middleware set** — composable middleware chain builder compatible with `net/http`
 - **Pagination** — generic, type-safe paginated list helper
@@ -67,6 +96,7 @@ summer -b main init
 ```
 
 summer will ask for a project name (used as the Go module name in `go.mod`). It creates:
+
 ```
 .
 ├── cmd/
@@ -248,16 +278,16 @@ writer.WriteErrorWithRequest(ctx, r, w, err, logger)
 
 #### Error-to-HTTP mapping (automatic)
 
-| Error | HTTP Status |
-|---|---|
-| `handlerutil.NotFoundError` / `ErrNotFound` | 404 Not Found |
-| `handlerutil.ValidationError` / `validator.ValidationErrors` / `ErrValidation` | 400 Bad Request |
-| `handlerutil.ErrUnauthorized` / `ErrCredentialInvalid` | 401 Unauthorized |
-| `handlerutil.ErrForbidden` | 403 Forbidden |
-| `handlerutil.ErrUserAlreadyExists` / `ErrInvalidUUID` | 400 Bad Request |
-| `databaseutil.InternalServerError` | 500 Internal Server Error |
-| `pagination.ErrInvalidPageOrSize` / `ErrInvalidSortingField` | 400 Bad Request |
-| anything else | 500 Internal Server Error |
+| Error                                                                          | HTTP Status               |
+| ------------------------------------------------------------------------------ | ------------------------- |
+| `handlerutil.NotFoundError` / `ErrNotFound`                                    | 404 Not Found             |
+| `handlerutil.ValidationError` / `validator.ValidationErrors` / `ErrValidation` | 400 Bad Request           |
+| `handlerutil.ErrUnauthorized` / `ErrCredentialInvalid`                         | 401 Unauthorized          |
+| `handlerutil.ErrForbidden`                                                     | 403 Forbidden             |
+| `handlerutil.ErrUserAlreadyExists` / `ErrInvalidUUID`                          | 400 Bad Request           |
+| `databaseutil.InternalServerError`                                             | 500 Internal Server Error |
+| `pagination.ErrInvalidPageOrSize` / `ErrInvalidSortingField`                   | 400 Bad Request           |
+| anything else                                                                  | 500 Internal Server Error |
 
 #### Problem constructors
 
@@ -369,7 +399,7 @@ srv := &http.Server{Handler: entrypoint}
 **Import path:** `github.com/NYCU-SDC/summer/pkg/database`  
 **Package name:** `databaseutil`
 
-Helpers for PostgreSQL (pgx) and MSSQL: schema migrations and error wrapping.
+Helpers for PostgreSQL (pgx) and MSSQL: schema migrations, transactions, and error wrapping.
 
 #### Migrations
 
@@ -399,14 +429,14 @@ err = databaseutil.WrapDBErrorWithKeyValue(err, "users", "id", id.String(), logg
 
 Mapped error types:
 
-| Database error | Wrapped as |
-|---|---|
-| `pgx.ErrNoRows` | `handlerutil.ErrNotFound` or `NotFoundError` |
-| `context.DeadlineExceeded` | `ErrQueryTimeout` |
-| PG code `23505` | `ErrUniqueViolation` |
-| PG code `23503` | `ErrForeignKeyViolation` |
-| PG code `40P01` | `ErrDeadlockDetected` |
-| anything else | `InternalServerError{Source: err}` |
+| Database error             | Wrapped as                                   |
+| -------------------------- | -------------------------------------------- |
+| `pgx.ErrNoRows`            | `handlerutil.ErrNotFound` or `NotFoundError` |
+| `context.DeadlineExceeded` | `ErrQueryTimeout`                            |
+| PG code `23505`            | `ErrUniqueViolation`                         |
+| PG code `23503`            | `ErrForeignKeyViolation`                     |
+| PG code `40P01`            | `ErrDeadlockDetected`                        |
+| anything else              | `InternalServerError{Source: err}`           |
 
 #### MSSQL error wrapping
 
@@ -415,6 +445,61 @@ Same API, same mapped error types, for Microsoft SQL Server:
 ```go
 err = databaseutil.WrapMSSQLError(err, logger, "create record")
 err = databaseutil.WrapMSSQLErrorWithKeyValue(err, "users", "id", id.String(), logger, "get user")
+```
+
+#### Transaction helpers
+
+`WithTransaction` and `WithTransactionQueries` run a callback inside a `pgx.Tx` lifecycle. Both `*pgxpool.Pool` and `pgx.Tx` satisfy `DBTX`, the minimal surface sqlc-generated `Queries` expect.
+
+- If `db` is already `pgx.Tx`, the callback runs on that transaction — no begin/commit/rollback here.
+- Otherwise `db` must implement `TxBeginner` (e.g. `*pgxpool.Pool`): begin, callback, commit on success, rollback on error or panic.
+- Return a non-nil error from the callback to abort and roll back. Do not call `Commit` or `Rollback` inside the callback unless you have a deliberate sub-transaction design.
+
+| API                                      | Use when                                               |
+| ---------------------------------------- | ------------------------------------------------------ |
+| `WithTransactionQueries` + `Run`         | All database access goes through sqlc queries          |
+| `WithTransactionQueries` + `RunWithDBTx` | The callback must pass `pgx.Tx` to another service     |
+| `WithTransaction` + `Run`                | The callback needs raw `pgx.Tx` without sqlc rebinding |
+
+Begin/commit failures are wrapped with `WrapDBError`. Unsupported connections return `ErrTransactionNotSupported`.
+
+##### WithTransactionQueries
+
+Prefer this for sqlc call sites. `Run` binds `queries.WithTx(tx)` for you; `RunWithDBTx` also passes `pgx.Tx` when another API needs the same transaction.
+
+```go
+// All work through transaction-scoped queries
+err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
+    Run(func(qtx *user.Queries) error {
+        err := qtx.Debit(ctx, params)
+        if err != nil {
+            return databaseutil.WrapDBError(err, logger, "debit account")
+        }
+
+        return qtx.Credit(ctx, creditParams)
+    })
+
+// Share pgx.Tx with another service in the same transaction
+err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
+    RunWithDBTx(func(tx pgx.Tx, qtx *user.Queries) error {
+        err := audit.Log(ctx, tx, event)
+        if err != nil {
+            return err
+        }
+
+        return qtx.RecordTransfer(ctx, transferParams)
+    })
+```
+
+##### WithTransaction
+
+Use when the callback needs raw `pgx.Tx` without sqlc rebinding:
+
+```go
+err := databaseutil.WithTransaction(ctx, pool, logger).Run(func(tx pgx.Tx) error {
+    _, err := tx.Exec(ctx, "UPDATE accounts SET balance = balance - $1 WHERE id = $2", amount, id)
+    return err
+})
 ```
 
 ---
@@ -578,6 +663,7 @@ func listUsersHandler(w http.ResponseWriter, r *http.Request) {
 ## Project Layout
 
 When you use `summer init`, your service should follow this layout:
+
 ```
 .
 ├── cmd/

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/golang-migrate/migrate/v4 v4.18.2
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.7.4
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/microsoft/go-mssqldb v1.9.6
 	github.com/spf13/cobra v1.9.1
 	go.opentelemetry.io/otel v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7Ulw
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.7.4 h1:9wKznZrhWa2QiHL+NjTSPP6yjl3451BX3imWDnokYlg=
 github.com/jackc/pgx/v5 v5.7.4/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -110,6 +112,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 h1:TT4fX+nBOA/+LUkobKGW1ydGcn+G3vRw9+g5HwCphpk=

--- a/pkg/database/tx.go
+++ b/pkg/database/tx.go
@@ -1,0 +1,87 @@
+package databaseutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.uber.org/zap"
+)
+
+// DBTX is the minimal database surface sqlc-generated Queries expect.
+// Both *pgxpool.Pool and pgx.Tx implement it.
+type DBTX interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+// TxBeginner can start a new database transaction.
+// *pgxpool.Pool satisfies this interface.
+type TxBeginner interface {
+	BeginTx(ctx context.Context, opts pgx.TxOptions) (pgx.Tx, error)
+}
+
+var ErrTransactionNotSupported = errors.New("database connection does not support transactions")
+
+// TxRunner configures a single transactional callback. It is not a database
+// transaction itself — nothing runs until Run is called.
+//
+// Prefer WithTransactionQueries for sqlc call sites; use WithTransaction only
+// when the callback needs raw pgx.Tx without sqlc rebinding.
+type TxRunner struct {
+	ctx    context.Context
+	db     DBTX
+	logger *zap.Logger
+}
+
+// WithTransaction builds a TxRunner for reuses an existing pgx.Tx).
+func WithTransaction(ctx context.Context, db DBTX, logger *zap.Logger) TxRunner {
+	return TxRunner{ctx: ctx, db: db, logger: logger}
+}
+
+// Run executes fn inside a transaction lifecycle:
+//
+//   - If db is already pgx.Tx, fn runs on that tx (no begin/commit here).
+//   - Otherwise db must implement TxBeginner: begin, fn, commit on success,
+//     rollback on error or panic (rollback is deferred).
+//
+// Return a non-nil error from fn to abort and roll back. Do not call Commit or
+// Rollback inside fn unless you have a deliberate sub-transaction design.
+func (t TxRunner) Run(fn func(pgx.Tx) error) error {
+	existingTx, ok := t.db.(pgx.Tx)
+	if ok {
+		return fn(existingTx)
+	}
+
+	beginner, ok := t.db.(TxBeginner)
+	if !ok {
+		return fmt.Errorf("%w", ErrTransactionNotSupported)
+	}
+
+	tx, err := beginner.BeginTx(t.ctx, pgx.TxOptions{})
+	if err != nil {
+		return WrapDBError(err, t.logger, "begin tx")
+	}
+
+	defer func() {
+		rollbackErr := tx.Rollback(t.ctx)
+		if rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			t.logger.Error("rollback failed", zap.Error(rollbackErr))
+		}
+	}()
+
+	err = fn(tx)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit(t.ctx)
+	if err != nil {
+		return WrapDBError(err, t.logger, "commit tx")
+	}
+
+	return nil
+}

--- a/pkg/database/tx_queries.go
+++ b/pkg/database/tx_queries.go
@@ -1,0 +1,52 @@
+package databaseutil
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+// WithTxBinder is satisfied by sqlc-generated Queries (WithTx rebinding).
+type WithTxBinder[T any] interface {
+	WithTx(pgx.Tx) T
+}
+
+// QueriesTx combines TxRunner with a sqlc binder so callbacks receive
+// transaction-scoped queries without manual WithTx calls.
+type QueriesTx[T any] struct {
+	TxRunner
+	binder WithTxBinder[T]
+}
+
+// WithTransactionQueries returns a TxRunner plus sqlc binder; call Run or RunWithDBTx.
+func WithTransactionQueries[T any](
+	ctx context.Context, db DBTX, logger *zap.Logger,
+	binder WithTxBinder[T],
+) QueriesTx[T] {
+	return QueriesTx[T]{
+		TxRunner: WithTransaction(ctx, db, logger),
+		binder:   binder,
+	}
+}
+
+// Run executes fn with sqlc queries bound to the transaction.
+// Equivalent to manually calling queries.WithTx(tx) inside WithTransaction.Run.
+//
+// Use Run when every database access in the callback goes through qtx.
+// Returning an error rolls back; nil commits (when this call owns the tx).
+func (q QueriesTx[T]) Run(fn func(T) error) error {
+	return q.TxRunner.Run(func(tx pgx.Tx) error {
+		return fn(q.binder.WithTx(tx))
+	})
+}
+
+// RunWithDBTx executes fn with both pgx.Tx and transaction-scoped queries.
+//
+// Use RunWithDBTx when the same transaction must be shared with another
+// sqlc-backed service or any API that accepts pgx.Tx
+func (q QueriesTx[T]) RunWithDBTx(fn func(pgx.Tx, T) error) error {
+	return q.TxRunner.Run(func(tx pgx.Tx) error {
+		return fn(tx, q.binder.WithTx(tx))
+	})
+}

--- a/pkg/database/tx_queries_test.go
+++ b/pkg/database/tx_queries_test.go
@@ -1,0 +1,69 @@
+package databaseutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+type stubQueries struct {
+	gotTx pgx.Tx
+}
+
+func (q *stubQueries) WithTx(tx pgx.Tx) *stubQueries {
+	q.gotTx = tx
+	return q
+}
+
+func TestWithTransactionQueries_Run(t *testing.T) {
+	t.Parallel()
+
+	tx := &trackTx{rollbackErr: pgx.ErrTxClosed}
+	beginner := &mockBeginner{tx: tx}
+	queries := &stubQueries{}
+
+	err := WithTransactionQueries(context.Background(), beginner, zap.NewNop(), queries).
+		Run(func(qtx *stubQueries) error {
+			if qtx.gotTx != tx {
+				t.Fatal("expected queries bound to active tx")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tx.committed {
+		t.Fatal("Commit not called")
+	}
+}
+
+func TestQueriesTx_RunWithDBTx(t *testing.T) {
+	t.Parallel()
+
+	tx := &trackTx{rollbackErr: pgx.ErrTxClosed}
+	beginner := &mockBeginner{tx: tx}
+	queries := &stubQueries{}
+
+	err := WithTransactionQueries(context.Background(), beginner, zap.NewNop(), queries).
+		RunWithDBTx(func(gotTx pgx.Tx, qtx *stubQueries) error {
+			if gotTx != tx {
+				t.Fatal("expected same tx instance")
+			}
+
+			if qtx.gotTx != tx {
+				t.Fatal("expected queries bound to active tx")
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !tx.committed {
+		t.Fatal("Commit not called")
+	}
+}

--- a/pkg/database/tx_test.go
+++ b/pkg/database/tx_test.go
@@ -1,0 +1,302 @@
+package databaseutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.uber.org/zap"
+)
+
+type stubDB struct{}
+
+func (stubDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (stubDB) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (stubDB) QueryRow(context.Context, string, ...any) pgx.Row {
+	return nil
+}
+
+type trackTx struct {
+	commitErr   error
+	rollbackErr error
+	committed   bool
+	rolledBack  bool
+}
+
+func (t *trackTx) Begin(context.Context) (pgx.Tx, error) {
+	return t, nil
+}
+
+func (t *trackTx) Commit(context.Context) error {
+	t.committed = true
+	return t.commitErr
+}
+
+func (t *trackTx) Rollback(context.Context) error {
+	t.rolledBack = true
+	return t.rollbackErr
+}
+
+func (t *trackTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+
+func (t *trackTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (t *trackTx) LargeObjects() pgx.LargeObjects {
+	return pgx.LargeObjects{}
+}
+
+func (t *trackTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	return nil, nil
+}
+
+func (t *trackTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (t *trackTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (t *trackTx) QueryRow(context.Context, string, ...any) pgx.Row { return nil }
+
+func (t *trackTx) Conn() *pgx.Conn { return nil }
+
+type mockBeginner struct {
+	tx        *trackTx
+	beginErr  error
+	beginCall int
+}
+
+func (m *mockBeginner) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (m *mockBeginner) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (m *mockBeginner) QueryRow(context.Context, string, ...any) pgx.Row {
+	return nil
+}
+
+func (m *mockBeginner) BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error) {
+	m.beginCall++
+	if m.beginErr != nil {
+		return nil, m.beginErr
+	}
+
+	return m.tx, nil
+}
+
+type withTransactionFixture struct {
+	db       DBTX
+	fn       func(pgx.Tx) error
+	tx       *trackTx
+	beginner *mockBeginner
+}
+
+func TestWithTransaction(t *testing.T) {
+	t.Parallel()
+
+	callbackErr := errors.New("callback failed")
+	beginErr := errors.New("begin failed")
+	commitErr := errors.New("commit failed")
+
+	testCases := []struct {
+		name     string
+		setup    func(t *testing.T) withTransactionFixture
+		validate func(t *testing.T, err error, f withTransactionFixture)
+	}{
+		{
+			name: "reuses existing tx",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{}
+				return withTransactionFixture{
+					db: tx,
+					fn: func(got pgx.Tx) error {
+						if got != tx {
+							t.Fatal("expected same tx instance")
+						}
+						return nil
+					},
+					tx: tx,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if f.tx.committed || f.tx.rolledBack {
+					t.Fatal("reused tx must not be committed or rolled back by helper")
+				}
+			},
+		},
+		{
+			name: "commits new tx",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{rollbackErr: pgx.ErrTxClosed}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return nil },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if f.beginner.beginCall != 1 {
+					t.Fatalf("BeginTx calls = %d, want 1", f.beginner.beginCall)
+				}
+				if !f.tx.committed {
+					t.Fatal("Commit not called")
+				}
+			},
+		},
+		{
+			name: "returns callback error",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return callbackErr },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, callbackErr) {
+					t.Fatalf("got %v, want %v", err, callbackErr)
+				}
+				if f.tx.committed {
+					t.Fatal("Commit should not run when callback fails")
+				}
+				if !f.tx.rolledBack {
+					t.Fatal("Rollback not called")
+				}
+			},
+		},
+		{
+			name: "returns callback error when rollback also fails",
+			setup: func(t *testing.T) withTransactionFixture {
+				rollbackErr := errors.New("rollback exploded")
+				tx := &trackTx{rollbackErr: rollbackErr}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return callbackErr },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, callbackErr) {
+					t.Fatalf("got %v, want callback error %v", err, callbackErr)
+				}
+				if f.tx.committed {
+					t.Fatal("Commit should not run when callback fails")
+				}
+				if !f.tx.rolledBack {
+					t.Fatal("Rollback not called")
+				}
+			},
+		},
+		{
+			name: "reuses existing tx callback error",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{}
+				return withTransactionFixture{
+					db: tx,
+					fn: func(pgx.Tx) error { return callbackErr },
+					tx: tx,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, callbackErr) {
+					t.Fatalf("got %v, want %v", err, callbackErr)
+				}
+				if f.tx.committed || f.tx.rolledBack {
+					t.Fatal("reused tx must not be committed or rolled back by helper")
+				}
+			},
+		},
+		{
+			name: "unsupported db",
+			setup: func(t *testing.T) withTransactionFixture {
+				return withTransactionFixture{
+					db: stubDB{},
+					fn: func(pgx.Tx) error { return nil },
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, ErrTransactionNotSupported) {
+					t.Fatalf("got %v, want %v", err, ErrTransactionNotSupported)
+				}
+			},
+		},
+		{
+			name: "wraps begin failure",
+			setup: func(t *testing.T) withTransactionFixture {
+				beginner := &mockBeginner{beginErr: beginErr}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return nil },
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				var wrapped InternalServerError
+				if !errors.As(err, &wrapped) {
+					t.Fatalf("expected wrapped db error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "wraps commit failure",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{commitErr: commitErr, rollbackErr: pgx.ErrTxClosed}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return nil },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				var wrapped InternalServerError
+				if !errors.As(err, &wrapped) {
+					t.Fatalf("expected wrapped db error, got %v", err)
+				}
+				if !f.tx.committed {
+					t.Fatal("Commit should have been attempted")
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := tc.setup(t)
+			err := WithTransaction(context.Background(), fixture.db, zap.NewNop()).Run(fixture.fn)
+			tc.validate(t, err, fixture)
+		})
+	}
+}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Provide reusable transaction lifecycle helpers for pgx and sqlc call sites
- Reduce boilerplate around begin, commit, rollback, and `WithTx` rebinding

## Additional Information
- Adds `WithTransaction` / `TxRunner` for raw `pgx.Tx` callbacks; reuses an existing tx when `db` is already `pgx.Tx`
- Adds `WithTransactionQueries` / `QueriesTx[T]` to bind sqlc-generated queries to the active transaction via `Run` and `RunWithDBTx`
- Includes unit tests in `pkg/database/tx_test.go` and `pkg/database/tx_queries_test.go`
- Bumps `github.com/jackc/pgx/v5` from v5.7.4 to v5.9.2

**Usage examples:**

```go
// sqlc-only callback
err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
    Run(func(qtx *db.Queries) error {
        return qtx.UpdateUser(ctx, params)
    })

// callback needs both pgx.Tx and sqlc queries
err := databaseutil.WithTransactionQueries(ctx, pool, logger, queries).
    RunWithDBTx(func(tx pgx.Tx, qtx *db.Queries) error {
        return otherService.DoWork(ctx, tx, qtx)
    })
```