### PR TITLE
Add CI to verify that the library is buildable and correct on style and format

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
       - run: go build ./...
 
   vet:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
       - run: go vet ./...
 
   format:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
       - run: gofmt -l . | tee /tmp/fmt.txt && test ! -s /tmp/fmt.txt
 
   test:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
       - run: go test ./... -race -cover
 
   cli-scaffold:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
       - name: CLI scaffolds a buildable project
         run: |
           go build -o /tmp/summer ./cmd/summer

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,8 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.26
       - run: go build ./...
@@ -16,8 +16,8 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.26
       - run: go vet ./...
@@ -25,8 +25,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.26
       - run: gofmt -l . | tee /tmp/fmt.txt && test ! -s /tmp/fmt.txt
@@ -34,8 +34,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.26
       - run: go test ./... -race -cover
@@ -43,8 +43,8 @@ jobs:
   cli-scaffold:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.26
       - name: CLI scaffolds a buildable project

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -50,4 +53,4 @@ jobs:
           cd $(mktemp -d)
           /tmp/summer -b main init <<< "testproject"
           go mod tidy
-          go build ./...
+          go build -o /tmp/build/ ./...

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,53 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25
+      - run: go build ./...
+
+  vet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25
+      - run: go vet ./...
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25
+      - run: gofmt -l . | tee /tmp/fmt.txt && test ! -s /tmp/fmt.txt
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25
+      - run: go test ./... -race -cover
+
+  cli-scaffold:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25
+      - name: CLI scaffolds a buildable project
+        run: |
+          go build -o /tmp/summer ./cmd/summer
+          cd $(mktemp -d)
+          /tmp/summer -b main init <<< "testproject"
+          go mod tidy
+          go build ./...

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,23 +13,16 @@ jobs:
           go-version: 1.26
       - run: go build ./...
 
-  vet:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
           go-version: 1.26
-      - run: go vet ./...
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
-          go-version: 1.26
-      - run: gofmt -l . | tee /tmp/fmt.txt && test ! -s /tmp/fmt.txt
+          version: v2.12
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - gofmt

--- a/cmd/summer/main.go
+++ b/cmd/summer/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -347,7 +348,12 @@ func copyFileContents(srcFile, dstFile string) (err error) {
 	if err != nil {
 		return
 	}
-	defer in.Close()
+	defer func(in *os.File) {
+		err := in.Close()
+		if err != nil {
+			return
+		}
+	}(in)
 
 	info, err := in.Stat()
 	if err != nil {
@@ -363,7 +369,10 @@ func copyFileContents(srcFile, dstFile string) (err error) {
 		if err != nil {
 			_ = os.Remove(dstFile)
 		}
-		out.Close()
+		err := out.Close()
+		if err != nil {
+			return
+		}
 	}()
 
 	_, err = io.Copy(out, in)

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -75,17 +75,6 @@ func WithContext(ctx context.Context, logger *zap.Logger) *zap.Logger {
 	return logger
 }
 
-// prettyEncodeCaller add padding to the caller string
-func prettyEncodeCaller(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
-	const fixedWidth = 25
-	callerStr := caller.TrimmedPath()
-	if len(callerStr) < fixedWidth {
-		callerStr += strings.Repeat(" ", fixedWidth-len(callerStr))
-	}
-	callerStr += "\t"
-	enc.AppendString(callerStr)
-}
-
 // relativePrettyCallerEncoder returns a zapcore.CallerEncoder that formats the caller path relative to the root directory
 // it enables clickable links in the GoLand console output
 func relativePrettyCallerEncoder(rootDir string) zapcore.CallerEncoder {


### PR DESCRIPTION
## Change type
- CI

## Purpose
- Add CI to test the following standards
    - Can build: `go build ./...`
    - Pass Go lint check: `golangci-lint run`
    - Pass all test cases: `go test ./... -race -cover`
    - Can use CLI tool to init a project
- Remove unused function in `pkg/log/logger.go`